### PR TITLE
Make draggable handle work for grand(^n)children

### DIFF
--- a/Scripts/Core/Runtime/Behaviours/SimpleSideMenu.cs
+++ b/Scripts/Core/Runtime/Behaviours/SimpleSideMenu.cs
@@ -169,7 +169,7 @@ namespace DanielLochner.Assets.SimpleSideMenu
                     Debug.LogError("<b>[SimpleSideMenu]</b> Transition speed cannot be less than or equal to zero.", gameObject);
                     valid = false;
                 }
-                if (handle != null && isHandleDraggable && handle.transform.parent != rectTransform)
+                if (handle != null && isHandleDraggable && !handle.transform.IsChildOf(rectTransform))
                 {
                     Debug.LogError("<b>[SimpleSideMenu]</b> The drag handle must be a child of the side menu in order for it to be draggable.", gameObject);
                     valid = false;


### PR DESCRIPTION
Draggable handle works so long as the handle is any descendent of the menu, so I changed this line in my instance and it seems to Just Work. Thank you again for making this, and for giving it away for free. I'm getting a ton of use out of it.